### PR TITLE
fix naming on transactionId vs reference

### DIFF
--- a/src/Message/CompletePurchaseResponse.php
+++ b/src/Message/CompletePurchaseResponse.php
@@ -14,9 +14,14 @@ class CompletePurchaseResponse extends CompleteAuthorizeResponse
         return isset($this->data['decision']) && 'ACCEPT' === $this->data['decision'];
     }
 
-    public function getTransactionReference()
+    public function getTransactionId()
     {
         return isset($this->data['req_reference_number']) ? $this->data['req_reference_number'] : null;
+    }
+
+    public function getTransactionReference()
+    {
+      return isset($this->data['transaction_id']) ? $this->data['transaction_id'] : null;
     }
 
     public function getMessage()


### PR DESCRIPTION
This is the application of

https://github.com/thephpleague/omnipay/issues/261

In effect the usage of transactionId & transactionReference has not been very clear. When I did some clarification it turned out to be the reverse of what is implemented here.

IMPORTANT - this change could affect upstream code by requiring the upstream function to call a different function